### PR TITLE
Fix native taps on Safari web elements.

### DIFF
--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -5,10 +5,7 @@ import log from '../logger';
 import _ from 'lodash';
 
 
-const EXTRA_WEB_COORD_SCROLL_OFFSET = -10;
-const IPHONE_WEB_COORD_OFFSET = -10;
 const IPHONE_WEB_COORD_SMART_APP_BANNER_OFFSET = 84;
-const IPAD_WEB_COORD_OFFSET = 10;
 const IPAD_WEB_COORD_SMART_APP_BANNER_OFFSET = 95;
 
 let extensions = {};
@@ -33,45 +30,31 @@ extensions.getElementHeightMemoized = _.memoize(async function (key, el) {
   return (await this.getNativeRect(el)).height;
 });
 
-extensions.getExtraTranslateWebCoordsOffset = async function () {
-  let offset = 0;
+extensions.getURLBarHeight = async function () {
+  let height = 0;
 
-  // keep track of implicit wait, and set locally to 0
+  // The elements comprising the URL bar are funny: many of them have children which are higher
+  // than themselves. We pick the highest one, an invisible nameless button which happens to be
+  // the first button in the app.
   const implicitWaitMs = this.implicitWaitMs;
-
-  // try to see if there has been scrolling
   try {
     this.setImplicitWait(0);
-
-    await this.findNativeElementOrElements('accessibility id', 'ReloadButton', false);
-    // reload button found, which means scrolling has not happened
-  } catch (err) {
-    // no reload button, which indicates scrolling has happened
-    try {
-      const el = await this.findNativeElementOrElements('accessibility id', 'URL', false);
-      offset -= await this.getElementHeightMemoized('URLBar', el);
-    } catch (ign) {
-      // no URL elements found, so continue
-    }
-
-    // when scrolling has happened, there is a tick more offset needed
-    offset += EXTRA_WEB_COORD_SCROLL_OFFSET;
+    let weirdButton = await this.findNativeElementOrElements('-ios predicate string', `type = "XCUIElementTypeButton"`, false);
+    weirdButton = util.unwrapElement(weirdButton);
+    height += (await this.getNativeRect(weirdButton)).height;
   } finally {
-    // return implicit wait to what it was
     this.setImplicitWait(implicitWaitMs);
   }
 
-  // extra offset necessary (where do these come from? they just work)
-  offset += await getSafariIsIphone(this.opts.sessionId, this) ?
-    IPHONE_WEB_COORD_OFFSET :
-    IPAD_WEB_COORD_OFFSET;
-
-  log.debug(`Extra translated web coordinates offset: ${offset}`);
-  return offset;
+  log.debug(`URL bar height: ${height}`);
+  return height;
 };
 
-extensions.getExtraNativeWebTapOffset = async function () {
-  let offset = 0;
+/**
+ * @returns {Promise.<number>} the total height of the tab bar and app banner elements, if present
+ */
+extensions.getHeightOfExtraTopElements = async function () {
+  let height = 0;
 
   // keep track of implicit wait, and set locally to 0
   const implicitWaitMs = this.implicitWaitMs;
@@ -81,7 +64,8 @@ extensions.getExtraNativeWebTapOffset = async function () {
     // first try to get tab offset
     try {
       const el = await this.findNativeElementOrElements('-ios predicate string', `name LIKE '*, Tab' AND visible = 1`, false);
-      offset += await this.getElementHeightMemoized('TabBar', el);
+      height += await this.getElementHeightMemoized('TabBar', el);
+      log.debug(`Adding height of tab bar`);
     } catch (ign) {
       // no element found, so no tabs and no need to deal with offset
     }
@@ -89,7 +73,8 @@ extensions.getExtraNativeWebTapOffset = async function () {
     // next try to see if there is an Smart App Banner
     try {
       await this.findNativeElementOrElements('accessibility id', 'Close app download offer', false);
-      offset += await getSafariIsIphone(this.opts.sessionId, this) ?
+      log.debug(`Adding height of app banner`);
+      height += await getSafariIsIphone(this.opts.sessionId, this) ?
         IPHONE_WEB_COORD_SMART_APP_BANNER_OFFSET :
         IPAD_WEB_COORD_SMART_APP_BANNER_OFFSET;
     } catch (ign) {
@@ -100,8 +85,8 @@ extensions.getExtraNativeWebTapOffset = async function () {
     this.setImplicitWait(implicitWaitMs);
   }
 
-  log.debug(`Additional native web tap offset computed: ${offset}`);
-  return offset;
+  log.debug(`Extra top elements height: ${height}`);
+  return height;
 };
 
 extensions.nativeWebTap = async function (el) {
@@ -122,17 +107,16 @@ extensions.clickCoords = async function (coords) {
   await this.proxyCommand('/wda/tap/nil', 'POST', {x, y});
 };
 
-extensions.translateWebCoords = async function (coords) {
-  log.debug(`Translating coordinates (${JSON.stringify(coords)}) to web coordinates`);
+extensions.getBottomBarHeight = async function () {
+  const bars = await this.findNativeElementOrElements("-ios predicate string", "name = 'BottomBrowserToolbar' AND visible = 1", true);
+  if (_.size(bars) === 0) {
+    return 0;
+  } else {
+    return await this.getElementHeightMemoized("BottomBrowserToolbar", bars[0]);
+  }
+};
 
-  // add static offset for safari in landscape mode
-  let yOffset = this.opts.curOrientation === 'LANDSCAPE' ? this.landscapeWebCoordsOffset : 0;
-
-  // add extra offset for possible extra things in the top of the page
-  yOffset += await this.getExtraNativeWebTapOffset();
-  coords.y += await this.getExtraTranslateWebCoordsOffset();
-
-  // absolutize web coords
+extensions.getWebviewNativeRect = async function () {
   let webview = await retryInterval(5, 100, async () => {
     const implicitWaitMs = this.implicitWaitMs;
     try {
@@ -145,37 +129,47 @@ extensions.translateWebCoords = async function (coords) {
 
   webview = util.unwrapElement(webview);
   let rect = await this.proxyCommand(`/element/${webview}/rect`, 'GET');
-  let wvPos = {x: rect.x, y: rect.y};
-  let realDims = {w: rect.width, h: rect.height};
+  log.debug(`Reported webview native rect: ${JSON.stringify(rect)}`);
 
-  let cmd = '(function () { return {w: document.documentElement.clientWidth, h: document.documentElement.clientHeight}; })()';
-  let wvDims = await this.remote.execute(cmd);
+  // The webview always reports its rect to be the same as the whole app, even though it's not.
+  // There are various elements above and below it. So we have to account for these elements
+  // ourselves.
 
-  // TODO: investigate where these come from. They appear to be constants in my tests
-  let urlBarHeight = 64;
-  wvPos.y += urlBarHeight;
+  let topElementsHeight = await this.getURLBarHeight();
+  topElementsHeight += await this.getHeightOfExtraTopElements();
 
-  let realDimensionHeight = 108;
-  realDims.h -= realDimensionHeight;
+  let bottomElementsHeight = await this.getBottomBarHeight();
 
-  if (wvDims && realDims && wvPos) {
-    let xRatio = realDims.w / wvDims.w;
-    let yRatio = realDims.h / wvDims.h;
+  rect.y += topElementsHeight;
+  rect.height -= (topElementsHeight + bottomElementsHeight);
+
+  log.debug(`Corrected webview native rect: ${JSON.stringify(rect)}`);
+  return rect;
+};
+
+extensions.translateWebCoords = async function (coords) {
+  log.debug(`Translating web coordinates (${JSON.stringify(coords)}) to native coordinates`);
+
+  let wvNativeRect = await this.getWebviewNativeRect();
+
+  let cmd = '(function () { return {width: window.innerWidth, height: window.innerHeight}; })()';
+  let wvWebDims = await this.remote.execute(cmd);
+
+  if (wvWebDims && wvNativeRect) {
+    let xRatio = wvNativeRect.width / wvWebDims.width;
+    let yRatio = wvNativeRect.height / wvWebDims.height;
     let newCoords = {
-      x: wvPos.x + Math.round(xRatio * coords.x),
-      y: wvPos.y + yOffset + Math.round(yRatio * coords.y),
+      x: wvNativeRect.x + Math.round(xRatio * coords.x),
+      y: wvNativeRect.y + Math.round(yRatio * coords.y),
     };
 
     // additional logging for coordinates, since it is sometimes broken
     //   see https://github.com/appium/appium/issues/9159
     log.debug(`Converted coordinates: ${JSON.stringify(newCoords)}`);
-    log.debug(`    rect: ${JSON.stringify(rect)}`);
-    log.debug(`    wvPos: ${JSON.stringify(wvPos)}`);
-    log.debug(`    realDims: ${JSON.stringify(realDims)}`);
-    log.debug(`    wvDims: ${JSON.stringify(wvDims)}`);
+    log.debug(`    rect: ${JSON.stringify(wvNativeRect)}`);
+    log.debug(`    wvDims: ${JSON.stringify(wvWebDims)}`);
     log.debug(`    xRatio: ${JSON.stringify(xRatio)}`);
     log.debug(`    yRatio: ${JSON.stringify(yRatio)}`);
-    log.debug(`    yOffset: ${JSON.stringify(yOffset)}`);
 
     log.debug(`Converted web coords ${JSON.stringify(coords)} ` +
               `into real coords ${JSON.stringify(newCoords)}`);


### PR DESCRIPTION
Rewrite the conversion from web (page) coordinates to native (device) coordinates:
- Don't behave differently when "scrolling has happened"; what's really different is the presence and size of the top and bottom bars, whose relationship with scrolling is complicated. The top bar can be two different sizes or (in landscape) absent; the bottom bar can be either present or absent.
- Remove magic numbers and instead fetch the sizes of relevant elements.
- Get the web dimensions of the webview correctly: we need the window size, not the document size.
- Be explicit that the reason we have to do most of this is that the webview reports nonsense dimensions.
- Rename various methods and variables for clarity.