### PR TITLE
Fix sporadic exceptions getting alert text when there is no alert

### DIFF
--- a/lib/commands/alert.js
+++ b/lib/commands/alert.js
@@ -142,7 +142,8 @@ helpers.getAlert = async function () {
   let assertButtonName = async (button, expectedName) => {
     button = button.ELEMENT ? button.ELEMENT : button;
     let name = await this.proxyCommand(`/element/${button}/attribute/name`, 'GET');
-    if (name.toLowerCase() !== expectedName) {
+    if (name === null || name.toLowerCase() !== expectedName) {
+      // `name` is `null` if there was a concurrent page load.
       throw new errors.NoAlertOpenError();
     }
   };


### PR DESCRIPTION
If a new page loads while we're checking a button name, we'll get `null` from WebDriverAgent. Report that there was no alert, since there can't have been one on the page we were called on.