### PR TITLE
[#154731241] Fix getting WebView size for native clicks

### DIFF
--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -123,7 +123,7 @@ extensions.getWebviewNativeRect = async function () {
     const implicitWaitMs = this.implicitWaitMs;
     try {
       this.setImplicitWait(0);
-      return await this.findNativeElementOrElements('-ios predicate string', `type = 'XCUIElementTypeWebView' AND visible = 1`, false);
+      return await this.findNativeElementOrElements('class name', 'XCUIElementTypeWebView', false);
     } finally {
       this.setImplicitWait(implicitWaitMs);
     }


### PR DESCRIPTION
* ios predicate "visible" querying broke depending on what was on the page, so remove it
* Move to more performant class name query if we're not using predicate features

Documentation of the performance of querying methods: https://github.com/facebook/WebDriverAgent/wiki/How-To-Achieve-The-Best-Lookup-Performance