### PR TITLE
[RD-30357] Fix clicking on web elements in the iPhone X.

### DIFF
--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -10,6 +10,8 @@ import B from 'bluebird';
 const IPHONE_WEB_COORD_SMART_APP_BANNER_OFFSET = 84;
 const IPAD_WEB_COORD_SMART_APP_BANNER_OFFSET = 95;
 
+const IPHONE_X_NOTCH_HEIGHT = 44;
+
 let extensions = {};
 
 Object.assign(extensions, iosCommands.web);
@@ -131,11 +133,15 @@ extensions.clickCoords = async function (coords) {
 
 extensions.getBottomBarHeight = async function () {
   const bars = await this.findNativeElementOrElements("-ios predicate string", "name = 'BottomBrowserToolbar' AND visible = 1", true);
+  let height = null;
   if (_.size(bars) === 0) {
-    return 0;
+    height = 0;
   } else {
-    return await this.getElementHeightMemoized("BottomBrowserToolbar", bars[0]);
+    height = await this.getElementHeightMemoized("BottomBrowserToolbar", bars[0]);
   }
+
+  log.debug(`Bottom bar height: ${height}`);
+  return height;
 };
 
 extensions.getWebviewNativeRect = async function () {
@@ -165,6 +171,15 @@ extensions.getWebviewNativeRect = async function () {
   rect.y += topElementsHeight;
   rect.height -= (topElementsHeight + bottomElementsHeight);
 
+  if (this.opts.deviceName === "iPhone X") {
+    let orientation = await this.proxyCommand("/orientation", "GET");
+    if (orientation === "LANDSCAPE") {
+      log.debug("Account for the iPhone X notch");
+      rect.x += IPHONE_X_NOTCH_HEIGHT;
+      rect.width -= IPHONE_X_NOTCH_HEIGHT * 2;
+    }
+  }
+
   log.debug(`Corrected webview native rect: ${JSON.stringify(rect)}`);
   return rect;
 };
@@ -178,11 +193,14 @@ extensions.translateWebCoords = async function (coords) {
   let wvWebDims = await this.remote.execute(cmd);
 
   if (wvWebDims && wvNativeRect) {
+    // On the iPhone X our "corrected" webview native rect has the wrong height. But the width
+    // is correct, so apply the x-ratio to the y-coordinate as well. Keep computing the y-ratio
+    // in case it helps debugging.
     let xRatio = wvNativeRect.width / wvWebDims.width;
     let yRatio = wvNativeRect.height / wvWebDims.height;
     let newCoords = {
       x: wvNativeRect.x + Math.round(xRatio * coords.x),
-      y: wvNativeRect.y + Math.round(yRatio * coords.y),
+      y: wvNativeRect.y + Math.round(xRatio * coords.y),
     };
 
     // additional logging for coordinates, since it is sometimes broken


### PR DESCRIPTION
- In portrait mode we compute the height of the webview's native rectangle incorrectly for an unknown reason. It must be something to do witn the notch or the curved corners, but it's unclear how. But the width is fine, so apply the ratio {{native-horizontal-pixels:web-horizontal-pixels}} to the vertical pixels as well.
- In landscape mode the notch causes the web content to be offset 44 pixels from the left edge of the device. Detect this case (iPhone X in landscape) and apply that offset to the left boundary of the webview's native rectangle.