### PR TITLE
[RD-31118] Optimise alert check by ensuring correct number of elements

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "WebDriverAgent"]
 	path = WebDriverAgent
-	url = https://github.com/appium/WebDriverAgent.git
+	url = https://github.com/scivisum/WebDriverAgent.git

--- a/lib/commands/alert.js
+++ b/lib/commands/alert.js
@@ -118,7 +118,7 @@ helpers.getAlert = async function () {
   }
 
   let possibleAlertButtons = await this.findNativeElementOrElements(
-      'class name', 'XCUIElementTypeButton', true, possibleAlert[0].ELEMENT
+    'class name', 'XCUIElementTypeButton', true, possibleAlert[0].ELEMENT
   );
 
   let assertButtonName = async (button, expectedName) => {

--- a/lib/commands/alert.js
+++ b/lib/commands/alert.js
@@ -94,15 +94,32 @@ commands.mobileHandleAlert = async function (opts = {}) {
 };
 
 helpers.getAlert = async function () {
-  let possibleAlert = await this.findNativeElementOrElements('class name', 'XCUIElementTypeScrollView', true);
+  // ScrollView should always be found, unless Safari isn't even running.
+  let possibleAlert = await this.findNativeElementOrElements(
+    'class name', 'XCUIElementTypeScrollView', true
+  );
   if (possibleAlert.length !== 1) {
     throw new errors.NoAlertOpenError();
   }
-
-  let possibleAlertButtons = await this.findNativeElementOrElements('class name', 'XCUIElementTypeButton', true, possibleAlert[0].ELEMENT);
-  if (possibleAlertButtons.length  < 1 || possibleAlertButtons.length > 2) {
+  let response;
+  // We expect exactly one TextView if an alert is present.
+  response = await this.findNativeElementOrElements(
+    'class name', 'XCUIElementTypeTextView', "count", possibleAlert[0].ELEMENT
+  );
+  if (response.count !== 1) {
     throw new errors.NoAlertOpenError();
   }
+  // We expect either one or two buttons if an alert is present.
+  response = await this.findNativeElementOrElements(
+    'class name', 'XCUIElementTypeButton', "count", possibleAlert[0].ELEMENT
+  );
+  if (response.count < 1 || response.count > 2) {
+    throw new errors.NoAlertOpenError();
+  }
+
+  let possibleAlertButtons = await this.findNativeElementOrElements(
+      'class name', 'XCUIElementTypeButton', true, possibleAlert[0].ELEMENT
+  );
 
   let assertButtonName = async (button, expectedName) => {
     button = button.ELEMENT ? button.ELEMENT : button;
@@ -138,12 +155,16 @@ helpers.getAlert = async function () {
   }
 
   alert.getText = async () => {
-    let textView = await this.findNativeElementOrElements('class name', 'XCUIElementTypeTextView', false, util.unwrapElement(alert));
+    let textView = await this.findNativeElementOrElements(
+      'class name', 'XCUIElementTypeTextView', false, util.unwrapElement(alert)
+    );
     return await this.proxyCommand(`/element/${textView.ELEMENT}/attribute/value`, 'GET');
   };
   alert.setText = async (value) => {
     try {
-      let textView = await this.findNativeElementOrElements('class name', 'XCUIElementTypeTextField', false, util.unwrapElement(alert));
+      let textView = await this.findNativeElementOrElements(
+        'class name', 'XCUIElementTypeTextField', false, util.unwrapElement(alert)
+      );
       await this.proxyCommand(`/element/${textView.ELEMENT}/value `, 'POST', {value});
     } catch (err) {
       if (isErrorType(err, errors.NoSuchElementError)) {

--- a/lib/commands/find.js
+++ b/lib/commands/find.js
@@ -93,7 +93,8 @@ helpers.doNativeFind = async function (strategy, selector, mult, context) {
 
   let body = {
     using: strategy,
-    value: selector
+    value: selector,
+    countOnly: mult === "count"
   };
 
   let method = 'POST';
@@ -103,7 +104,7 @@ helpers.doNativeFind = async function (strategy, selector, mult, context) {
     await this.implicitWaitForCondition(async () => {
       try {
         els = await this.proxyCommand(endpoint, method, body);
-        if (mult) {
+        if (mult && mult !== "count") {
           // we succeed if we get some elements
           return els && els.length;
         } else {

--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -50,15 +50,15 @@ extensions.getURLBarHeight = async function (rect) {
     // Don't trust the "weirdButton" check in landscape, because it always has a size, even if it's not visible.
     let navBarVisible = false;
     if (rect.width > rect.height) {
-        let topBrowsers = await this.findNativeElementOrElements('-ios predicate string', `name = "TopBrowserToolbar"`, true);
-        navBarVisible = _.size(topBrowsers) > 0
+      let topBrowsers = await this.findNativeElementOrElements('-ios predicate string', `name = "TopBrowserToolbar"`, true);
+      navBarVisible = _.size(topBrowsers) > 0;
     } else {
-        navBarVisible = true;
+      navBarVisible = true;
     }
     if (navBarVisible) {
-        let weirdButton = await this.findNativeElementOrElements('-ios predicate string', `type = "XCUIElementTypeButton"`, false);
-        weirdButton = util.unwrapElement(weirdButton);
-        height += (await this.getNativeRect(weirdButton)).height;
+      let weirdButton = await this.findNativeElementOrElements('-ios predicate string', `type = "XCUIElementTypeButton"`, false);
+      weirdButton = util.unwrapElement(weirdButton);
+      height += (await this.getNativeRect(weirdButton)).height;
     }
   } finally {
     this.setImplicitWait(implicitWaitMs);
@@ -223,9 +223,10 @@ extensions.checkForAlert = async function (isRetroactive) {
   let alert_ = null;
   try {
     alert_ = await this.getAlert();
-  } catch(err) {
+  } catch (err) {
     // No alert found
   }
+
   if (alert_) {
     let message;
     if (isRetroactive) {
@@ -272,11 +273,13 @@ extensions.waitForAtom = async function (promise) {
     error = err;
   });
   // Wait until either action succeeds or it's taking too long and we want to check for alerts.
-  let timeoutPromise = B.delay(1000).then(()=>timedOut = true);
+  let timeoutPromise = B.delay(1000).then(() => timedOut = true);
   await Promise.race([promise, timeoutPromise]);
   if (timedOut) {
     for (let i = 0; i < 10; i++) {
-      if (done) break;
+      if (done) {
+        break;
+      }
       // check if there is an alert (will throw exception if one is found).
       await this.checkForAlert(true);
       await B.delay(500);

--- a/test/unit/commands/alert-specs.js
+++ b/test/unit/commands/alert-specs.js
@@ -3,6 +3,7 @@ import XCUITestDriver from '../../..';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 
+import { errors } from 'appium-base-driver';
 
 chai.should();
 chai.use(chaiAsPromised);
@@ -48,6 +49,79 @@ describe('alert commands', function () {
       proxySpy.calledOnce.should.be.true;
       proxySpy.firstCall.args[0].should.eql('/alert/dismiss');
       proxySpy.firstCall.args[1].should.eql('POST');
+    });
+  });
+
+  describe('getAlert', function () {
+    let scrollView = sinon.stub();
+    scrollView.ELEMENT = "mockscrollelement";
+
+    it('returns successfully if an alert is present', async function () {
+      let button = sinon.stub(),
+          alert;
+      button.ELEMENT = "mockbuttonelement";
+      proxySpy.onCall(0).returns([scrollView]);
+      proxySpy.onCall(1).returns({count: 1});
+      proxySpy.onCall(2).returns({count: 1});
+      proxySpy.onCall(3).returns([button]);
+      proxySpy.onCall(4).returns("close");
+
+      alert = await driver.getAlert();
+
+      proxySpy.getCall(0).args[0].should.eql('/elements');
+      proxySpy.getCall(0).args[2].should.eql({
+        using: 'class name', value: 'XCUIElementTypeScrollView', countOnly: false
+      });
+      proxySpy.getCall(1).args[0].should.eql('/element/mockscrollelement/elements');
+      proxySpy.getCall(1).args[2].should.eql({
+        using: 'class name', value: 'XCUIElementTypeTextView', countOnly: true
+      });
+      proxySpy.getCall(2).args[0].should.eql('/element/mockscrollelement/elements');
+      proxySpy.getCall(2).args[2].should.eql({
+        using: 'class name', value: 'XCUIElementTypeButton', countOnly: true
+      });
+      proxySpy.getCall(3).args[0].should.eql('/element/mockscrollelement/elements');
+      proxySpy.getCall(3).args[2].should.eql({
+        using: 'class name', value: 'XCUIElementTypeButton', countOnly: false
+      });
+      proxySpy.getCall(4).args[0].should.eql('/element/mockbuttonelement/attribute/name');
+      alert.should.eql(scrollView);
+    });
+
+    it('returns successfully if a confirm is present', async function () {
+      let button1 = sinon.stub(),
+          button2 = sinon.stub(),
+          alert;
+      button1.ELEMENT = "mockbuttonelement1";
+      button2.ELEMENT = "mockbuttonelement2";
+      proxySpy.onCall(0).returns([scrollView]);
+      proxySpy.onCall(1).returns({count: 1});
+      proxySpy.onCall(2).returns({count: 2});
+      proxySpy.onCall(3).returns([button1, button2]);
+      proxySpy.onCall(4).returns("cancel");
+      proxySpy.onCall(5).returns("ok");
+
+      alert = await driver.getAlert();
+
+      proxySpy.callCount.should.equal(6);
+      proxySpy.getCall(4).args[0].should.eql('/element/mockbuttonelement1/attribute/name');
+      proxySpy.getCall(5).args[0].should.eql('/element/mockbuttonelement2/attribute/name');
+      alert.should.eql(scrollView);
+    });
+    it('throws on incorrect number of TextViews', async function () {
+      proxySpy.onCall(0).returns([scrollView]);
+      proxySpy.onCall(1).returns({count: 0});
+
+      await driver.getAlert().should.be.rejectedWith(errors.NoAlertOpenError);
+      proxySpy.callCount.should.equal(2);
+    });
+    it('throws on incorrect number of Buttons', async function () {
+      proxySpy.onCall(0).returns([scrollView]);
+      proxySpy.onCall(1).returns({count: 1});
+      proxySpy.onCall(2).returns({count: 3});
+
+      await driver.getAlert().should.be.rejectedWith(errors.NoAlertOpenError);
+      proxySpy.callCount.should.equal(3);
     });
   });
 

--- a/test/unit/commands/find-specs.js
+++ b/test/unit/commands/find-specs.js
@@ -21,7 +21,7 @@ describe('general commands', function () {
       proxySpy.firstCall.args[1].should.eql('POST');
       proxySpy.firstCall.args[2].should.eql({
         using: modStrategy || strategy,
-        value: modSelector
+        value: modSelector, countOnly: mult === "count"
       });
       proxySpy.reset();
     }
@@ -60,6 +60,10 @@ describe('general commands', function () {
                         '//XCUIElementTypeMap[@name="UIADummyData"]');
     });
 
+    it('should only count if mult is "count"', async function () {
+      await verifyFind('xpath', '//UIAButton', '//XCUIElementTypeButton', null, "count");
+    });
+
     it('should reject request for first visible child with no context', async function () {
       await driver.findNativeElementOrElements(
         'xpath', '/*[@firstVisible="true"]', false)
@@ -83,12 +87,12 @@ describe('general commands', function () {
         proxySpy.withArgs(
           '/element/ctx/element',
           'POST',
-          {using: 'class chain', value: '*[1]'}
+          {using: 'class chain', value: '*[1]', countOnly: false}
         ).returns({ELEMENT: 1});
         proxySpy.withArgs(
           '/element/ctx/element',
           'POST',
-          {using: 'class chain', value: '*[2]'}
+          {using: 'class chain', value: '*[2]', countOnly: false}
         ).returns({ELEMENT: 2});
         attribSpy.withArgs('visible', {ELEMENT: 1}).returns("false");
         attribSpy.withArgs('visible', {ELEMENT: 2}).returns("true");
@@ -97,11 +101,11 @@ describe('general commands', function () {
         proxySpy.calledTwice.should.be.true;
         proxySpy.firstCall.args[2].should.eql({
           using: 'class chain',
-          value: '*[1]',
+          value: '*[1]', countOnly: false
         });
         proxySpy.secondCall.args[2].should.eql({
           using: 'class chain',
-          value: '*[2]',
+          value: '*[2]', countOnly: false
         });
         attribSpy.calledTwice.should.be.true;
         el.should.eql({ELEMENT: 2});


### PR DESCRIPTION
* Re-use `mult` parameter and give it a trinary meaning: `false`, `true`
or `"count"`, where `"count"` adds the `countOnly` request body
parameter to be sent to WDA's `/elements` endpoint.
* Use this to ensure the necessary number of `TextView` and `Button`
elements exist before doing the more expensive full-on element queries.
* Updated the WebDriverAgent submodule to the scivisum repo, with
(optimistically) the commit implementing `countOnly`.