### PR TITLE
[RD-31120] Add a flag to disable modal dialog checking

### DIFF
--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -221,7 +221,6 @@ extensions.translateWebCoords = async function (coords) {
 
 extensions.checkForAlert = async function (isRetroactive) {
   if (!this.settings.getSettings().checkForModalDialogs) {
-    log.debug("Alert checking disabled");
     return;
   }
   let alert_ = null;

--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -220,6 +220,10 @@ extensions.translateWebCoords = async function (coords) {
 };
 
 extensions.checkForAlert = async function (isRetroactive) {
+  if (!this.settings.getSettings().checkForModalDialogs) {
+    log.debug("Alert checking disabled");
+    return;
+  }
   let alert_ = null;
   try {
     alert_ = await this.getAlert();

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -33,6 +33,7 @@ const DEFAULT_SETTINGS = {
   useJSONSource: false,
   shouldUseCompactResponses: true,
   elementResponseAttributes: "type,label",
+  checkForModalDialogs: true
 };
 // This lock assures, that each driver session does not
 // affect shared resources of the other parallel sessions


### PR DESCRIPTION
* New `DeviceSettings` flag, `checkForModalDialogs`, mirroring our
engine flag by the same name.
* If this flag is `true` then skip the modal dialog checks.