### PR TITLE
[RD-31456] Remove unreliable clicking method added by appium.

### DIFF
--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -107,41 +107,8 @@ extensions.getHeightOfExtraTopElements = async function () {
   return height;
 };
 
-async function tapWebElementNatively (driver, atomsElement) {
-  // try to get the text of the element, which will be accessible in the
-  // native context
-  try {
-    let text = await driver.executeAtom('get_text', [atomsElement]);
-    if (!text) {
-      text = await driver.executeAtom('get_attribute_value', [atomsElement, 'value']);
-    }
-
-    if (text) {
-      const el = await driver.findNativeElementOrElements('accessibility id', text, false);
-      // use tap because on iOS 11.2 and below `nativeClick` crashes WDA
-      const rect = await driver.proxyCommand(`/element/${el.ELEMENT}/rect`, 'GET');
-      const coords = {
-        x: rect.x + rect.width / 2,
-        y: rect.y + rect.height / 2,
-      };
-      await driver.clickCoords(coords);
-      return true;
-    }
-  } catch (err) {
-    // any failure should fall through and trigger the more elaborate
-    // method of clicking
-    log.warn(`Error attempting to click: ${err.message}`);
-  }
-  return false;
-}
-
 extensions.nativeWebTap = async function (el) {
   const atomsElement = this.useAtomsElement(el);
-
-  if (await tapWebElementNatively(this, atomsElement)) {
-    return;
-  }
-  log.warn('Unable to do simple native web tap. Attempting to convert coordinates');
 
   // `get_top_left_coordinates` returns the wrong value sometimes,
   // unless we pre-call both of these functions before the actual calls


### PR DESCRIPTION
This could best be described as "optimistic". It finds an element with accessibility ID matching the text of the element to click on, and clicks on that. It fails on the very first click I tried, because there is a text element in the page with the same content.